### PR TITLE
[1.0.2]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.8
 
 intellij {
     plugins 'java'
-    version '2020.2'
+    version '2020.3'
     downloadSources = false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 groupId=com.github.goodforgod
 artifactId=dummymapper
-artifactVersion=1.1.0-SNAPSHOT
+artifactVersion=1.0.2
 
 
 ##### GRADLE #####

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 groupId=com.github.goodforgod
 artifactId=dummymapper
-artifactVersion=1.0.1
+artifactVersion=1.1.0-SNAPSHOT
 
 
 ##### GRADLE #####

--- a/src/main/java/io/goodforgod/dummymapper/mapper/IMapper.java
+++ b/src/main/java/io/goodforgod/dummymapper/mapper/IMapper.java
@@ -4,7 +4,6 @@ import com.intellij.psi.PsiJavaFile;
 import io.goodforgod.dummymapper.marker.RawMarker;
 import io.goodforgod.dummymapper.ui.config.IConfig;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Map contract to map instance of {@link PsiJavaFile} to format as string value
@@ -26,5 +25,5 @@ public interface IMapper<T extends IConfig> {
      * @throws io.goodforgod.dummymapper.error.MapperException in case of map exception
      */
     @NotNull
-    String map(@NotNull RawMarker marker, @Nullable T config);
+    String map(@NotNull RawMarker marker, T config);
 }

--- a/src/main/java/io/goodforgod/dummymapper/mapper/impl/AvroJacksonMapper.java
+++ b/src/main/java/io/goodforgod/dummymapper/mapper/impl/AvroJacksonMapper.java
@@ -19,7 +19,6 @@ import io.goodforgod.dummymapper.service.ClassFactory;
 import io.goodforgod.dummymapper.ui.config.AvroJacksonConfig;
 import org.apache.avro.Schema;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -36,18 +35,18 @@ public class AvroJacksonMapper implements IMapper<AvroJacksonConfig> {
 
     private final IFilter emptyFilter = new EmptyMarkerFilter();
     private final IFilter avroFilter = new AvroFilter();
-    private final IFilter propertyFilter = new JacksonPropertyFilter();
+    private final IFilter requiredFieldFilter = new JacksonPropertyFilter();
     private final IFilter annotationFilter = new ExcludeSetterAnnotationFilter();
     private final ObjectMapper mapper = new ObjectMapper(new AvroFactory());
 
     @NotNull
     @Override
-    public String map(@NotNull RawMarker marker, @Nullable AvroJacksonConfig config) {
+    public String map(@NotNull RawMarker marker, AvroJacksonConfig config) {
         try {
             final RawMarker filtered = Optional.of(marker)
                     .map(avroFilter::filter)
                     .map(annotationFilter::filter)
-                    .map(propertyFilter::filter)
+                    .map(r -> config.isRequiredByDefault() ? requiredFieldFilter.filter(r) : r)
                     .map(emptyFilter::filter)
                     .orElseThrow(() -> new IllegalArgumentException("Not filter present!"));
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,12 +22,10 @@
         <img width="520" height="270" src="https://i.ibb.co/S7XJv6W/dummyjson.gif" />
     ]]></description>
     <change-notes><![CDATA[
-        <i>Features or changes in this release</i>
+        <i>Features or changes in this release:</i>
         <ul>
-            <li>Fixed AVRO namespace mapping.</li>
-            <li>Fixed path scanning on OSX.</li>
-            <li>Fixed java.time.* package serialization in ISO8601 format when mapping to Json.</li>
-            <li>Compatibility with IDEA 2020.2+</li>
+            <li>Map as Avro (Jackson) required by default fixed</li>
+            <li>Compatibility with IDEA 2020.3+</li>
         </ul>
     ]]></change-notes>
 


### PR DESCRIPTION
Release [1.0.2] ready:
- Compatibility with IDEA 2020.3+
- Avro Jackson mapper required by default fixed.